### PR TITLE
Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,3 @@ You can convert `NSDate` instances to a string:
 print(date.toISO8601GMTString())
 1971-02-03T09:16:06Z
 ```
-
-## Known Issues
-
-- No :penguin: support for now, as `getVaList()` is unavailable (see <https://github.com/apple/swift/blob/a30ae2bf55e21859418da6b8cd28273d5b71719c/stdlib/public/core/VarArgs.swift#L80-L83>).

--- a/Sources/Clock/ISO8601Parser.swift
+++ b/Sources/Clock/ISO8601Parser.swift
@@ -69,8 +69,8 @@ extension tm {
   tm_min = Int32(dateTuple.minute)
   tm_hour = Int32(dateTuple.hour)
   tm_mday = Int32(dateTuple.day)
-  tm_mon = Int32(dateTuple.month)
-  tm_year = Int32(dateTuple.year)
+  tm_mon = Int32(dateTuple.month - 1)
+  tm_year = Int32(dateTuple.year - 1900)
   tm_wday = 0
   tm_yday = 0
   tm_isdst = 0

--- a/Sources/Clock/ISO8601Parser.swift
+++ b/Sources/Clock/ISO8601Parser.swift
@@ -1,7 +1,7 @@
 #if os(Linux)
-import Glibc
+    import Glibc
 #else
-import Darwin
+    import Darwin
 #endif
 
 typealias DateTuple = (year: Int, month: Int, day: Int,
@@ -10,119 +10,105 @@ typealias DateTuple = (year: Int, month: Int, day: Int,
 
 /// Parser for ISO8601 dates
 public struct ISO8601 {
-  static let TZ_MINUS_FORMAT = "%04d-%02d-%02dT%02d:%02d:%lf-%02d:%02d"
-  static let TZ_MINUS_FORMAT_NO_COLON = "%04d-%02d-%02dT%02d:%02d:%lf-%02d%02d"
-  static let TZ_PLUS_FORMAT = "%04d-%02d-%02dT%02d:%02d:%lf+%02d:%02d"
-  static let TZ_PLUS_FORMAT_NO_COLON = "%04d-%02d-%02dT%02d:%02d:%lf+%02d%02d"
-  static let UTC_FORMAT = "%04d-%02d-%02dT%02d:%02d:%lfZ"
+    static let TZ_MINUS_FORMAT = "%04d-%02d-%02dT%02d:%02d:%lf-%02d:%02d"
+    static let TZ_MINUS_FORMAT_NO_COLON = "%04d-%02d-%02dT%02d:%02d:%lf-%02d%02d"
+    static let TZ_PLUS_FORMAT = "%04d-%02d-%02dT%02d:%02d:%lf+%02d:%02d"
+    static let TZ_PLUS_FORMAT_NO_COLON = "%04d-%02d-%02dT%02d:%02d:%lf+%02d%02d"
+    static let UTC_FORMAT = "%04d-%02d-%02dT%02d:%02d:%lfZ"
 
-  static func parse(dateString: String, withFormat format: String, failAt: Int32 = 5) -> DateTuple? {
-    var y: Int32 = 0
-    var m: Int32 = 0
-    var d: Int32 = 0
-    var h: Int32 = 0
-    var mm: Int32 = 0
-    var s: Double = 0
-    var tz_h: Int32 = 0
-    var tz_m: Int32 = 0
+    static func parse(dateString: String, withFormat format: String, failAt: Int32 = 5) -> DateTuple? {
+        var y: Int32 = 0
+        var m: Int32 = 0
+        var d: Int32 = 0
+        var h: Int32 = 0
+        var mm: Int32 = 0
+        var s: Double = 0
+        var tz_h: Int32 = 0
+        var tz_m: Int32 = 0
 
-    var result: Int32 = 0
+        var result: Int32 = 0
 
-    withUnsafeMutablePointers(&y, &m, &d) { y, m, d in
-      withUnsafeMutablePointers(&h, &mm, &s) { h, mm, s in
-        withUnsafeMutablePointers(&tz_h, &tz_m) { tz_h, tz_m in
-          let args: [CVarArgType] = [y, m, d, h, mm, s, tz_h, tz_m]
-          withVaList(args) {
-            result = vsscanf(dateString, format, $0)
-          }
+        withUnsafeMutablePointers(&y, &m, &d) { y, m, d in
+            withUnsafeMutablePointers(&h, &mm, &s) { h, mm, s in
+                withUnsafeMutablePointers(&tz_h, &tz_m) { tz_h, tz_m in
+                    let args: [CVarArgType] = [y, m, d, h, mm, s, tz_h, tz_m]
+                    withVaList(args) {
+                        result = vsscanf(dateString, format, $0)
+                    }
+                }
+            }
         }
-      }
-    }
 
-    if result < failAt {
-      return nil
-    }
+        if result < failAt {
+            return nil
+        }
 
-    return (Int(y), Int(m), Int(d), Int(h), Int(mm), Int(s), Int(tz_h), Int(tz_m))
-  }
+        return (Int(y), Int(m), Int(d), Int(h), Int(mm), Int(s), Int(tz_h), Int(tz_m))
+    }
 }
 
 import Foundation
 
 private extension NSDateComponents {
-  func fill(dateTuple: DateTuple) -> NSDateComponents {
-    self.year = dateTuple.year
-    self.month = dateTuple.month
-    self.day = dateTuple.day
-    self.hour = dateTuple.hour
-    self.minute = dateTuple.minute
-    self.second = dateTuple.second
-    self.timeZone = NSTimeZone(forSecondsFromGMT: dateTuple.timezone_hour * 60 * 60 
-        + dateTuple.timezone_minute * 60)
-    return self
-  }
+    func fill(dateTuple: DateTuple) -> NSDateComponents {
+        self.year = dateTuple.year
+        self.month = dateTuple.month
+        self.day = dateTuple.day
+        self.hour = dateTuple.hour
+        self.minute = dateTuple.minute
+        self.second = dateTuple.second
+        self.timeZone = NSTimeZone(forSecondsFromGMT: dateTuple.timezone_hour * 60 * 60
+            + dateTuple.timezone_minute * 60)
+        return self
+    }
 }
 
 extension tm {
-  init(dateTuple: DateTuple) {
-  tm_sec = Int32(dateTuple.second)
-  tm_min = Int32(dateTuple.minute)
-  tm_hour = Int32(dateTuple.hour)
-  tm_mday = Int32(dateTuple.day)
-  tm_mon = Int32(dateTuple.month - 1)
-  tm_year = Int32(dateTuple.year - 1900)
-  tm_wday = 0
-  tm_yday = 0
-  tm_isdst = 0
-  tm_gmtoff = dateTuple.timezone_hour * 60 * 60 + dateTuple.timezone_minute * 60
-  tm_zone = nil
-  }
+    init(dateTuple: DateTuple) {
+        tm_sec = Int32(dateTuple.second)
+        tm_min = Int32(dateTuple.minute)
+        tm_hour = Int32(dateTuple.hour)
+        tm_mday = Int32(dateTuple.day)
+        tm_mon = Int32(dateTuple.month - 1)
+        tm_year = Int32(dateTuple.year - 1900)
+        tm_wday = 0
+        tm_yday = 0
+        tm_isdst = 0
+        tm_gmtoff = dateTuple.timezone_hour * 60 * 60 + dateTuple.timezone_minute * 60
+        tm_zone = nil
+    }
 }
 
 extension ISO8601 {
-  public static func parse(dateString: String) -> tm {
-  for format in [TZ_MINUS_FORMAT, TZ_MINUS_FORMAT_NO_COLON] {
-      if let t = parse(dateString, withFormat: format, failAt: 8) {
-        return tm(dateTuple: (t.year, t.month, t.day, t.hour, t.minute, t.second,
-            -t.timezone_hour, -t.timezone_minute))
-      }
+    private static func parse(dateString: String) -> DateTuple {
+        for format in [TZ_MINUS_FORMAT, TZ_MINUS_FORMAT_NO_COLON] {
+            if let t = parse(dateString, withFormat: format, failAt: 8) {
+                return (t.year, t.month, t.day, t.hour, t.minute, t.second, -t.timezone_hour, -t.timezone_minute)
+            }
+        }
+
+        for format in [TZ_PLUS_FORMAT, TZ_PLUS_FORMAT_NO_COLON] {
+            if let dateTuple = parse(dateString, withFormat: format, failAt: 8) {
+                return dateTuple
+            }
+        }
+
+        if let dateTuple = parse(dateString, withFormat: UTC_FORMAT) {
+            return dateTuple
+        }
+        
+        return (0,0,0,0,0,0,0,0)
     }
-
-    for format in [TZ_PLUS_FORMAT, TZ_PLUS_FORMAT_NO_COLON] {
-      if let dateTuple = parse(dateString, withFormat: format, failAt: 8) {
-        return tm(dateTuple: dateTuple)
-      }
+    
+    public static func parse(dateString: String) -> tm {
+        let tuple: DateTuple = parse(dateString)
+        return tm(dateTuple: tuple) 
     }
-
-    if let dateTuple = parse(dateString, withFormat: UTC_FORMAT) {
-      return tm(dateTuple: dateTuple)
+    
+    /// Parses an ISO8601 string, returning a coressponding NSDateComponents instance
+    public static func parse(dateString: String) -> NSDateComponents {
+        let components = NSDateComponents()
+        let tuple: DateTuple = parse(dateString)
+        return components.fill(tuple)
     }
-
-    let tuple: DateTuple = (0,0,0,0,0,0,0,0)
-    return tm(dateTuple: tuple)  
-  }
-
-/// Parses an ISO8601 string, returning a coressponding NSDateComponents instance
-  public static func parse(dateString: String) -> NSDateComponents {
-    let components = NSDateComponents()
-
-    for format in [TZ_MINUS_FORMAT, TZ_MINUS_FORMAT_NO_COLON] {
-      if let t = parse(dateString, withFormat: format, failAt: 8) {
-        return components.fill((t.year, t.month, t.day, t.hour, t.minute, t.second,
-            -t.timezone_hour, -t.timezone_minute))
-      }
-    }
-
-    for format in [TZ_PLUS_FORMAT, TZ_PLUS_FORMAT_NO_COLON] {
-      if let dateTuple = parse(dateString, withFormat: format, failAt: 8) {
-        return components.fill(dateTuple)
-      }
-    }
-
-    if let dateTuple = parse(dateString, withFormat: UTC_FORMAT) {
-      return components.fill(dateTuple)
-    }
-
-    return components
-  }
 }

--- a/Sources/Clock/ISO8601Parser.swift
+++ b/Sources/Clock/ISO8601Parser.swift
@@ -63,8 +63,46 @@ private extension NSDateComponents {
   }
 }
 
+extension tm {
+  init(dateTuple: DateTuple) {
+  tm_sec = Int32(dateTuple.second)
+  tm_min = Int32(dateTuple.minute)
+  tm_hour = Int32(dateTuple.hour)
+  tm_mday = Int32(dateTuple.day)
+  tm_mon = Int32(dateTuple.month)
+  tm_year = Int32(dateTuple.year)
+  tm_wday = 0
+  tm_yday = 0
+  tm_isdst = 0
+  tm_gmtoff = dateTuple.timezone_hour * 60 * 60 + dateTuple.timezone_minute * 60
+  tm_zone = nil
+  }
+}
+
 extension ISO8601 {
-  /// Parses an ISO8601 string, returning a coressponding NSDateComponents instance
+  public static func parse(dateString: String) -> tm {
+  for format in [TZ_MINUS_FORMAT, TZ_MINUS_FORMAT_NO_COLON] {
+      if let t = parse(dateString, withFormat: format, failAt: 8) {
+        return tm(dateTuple: (t.year, t.month, t.day, t.hour, t.minute, t.second,
+            -t.timezone_hour, -t.timezone_minute))
+      }
+    }
+
+    for format in [TZ_PLUS_FORMAT, TZ_PLUS_FORMAT_NO_COLON] {
+      if let dateTuple = parse(dateString, withFormat: format, failAt: 8) {
+        return tm(dateTuple: dateTuple)
+      }
+    }
+
+    if let dateTuple = parse(dateString, withFormat: UTC_FORMAT) {
+      return tm(dateTuple: dateTuple)
+    }
+
+    let tuple: DateTuple = (0,0,0,0,0,0,0,0)
+    return tm(dateTuple: tuple)  
+  }
+
+/// Parses an ISO8601 string, returning a coressponding NSDateComponents instance
   public static func parse(dateString: String) -> NSDateComponents {
     let components = NSDateComponents()
 

--- a/Sources/Clock/ISO8601Parser.swift
+++ b/Sources/Clock/ISO8601Parser.swift
@@ -32,7 +32,9 @@ public struct ISO8601 {
       withUnsafeMutablePointers(&h, &mm, &s) { h, mm, s in
         withUnsafeMutablePointers(&tz_h, &tz_m) { tz_h, tz_m in
           let args: [CVarArgType] = [y, m, d, h, mm, s, tz_h, tz_m]
-          result = vsscanf(dateString, format, getVaList(args))
+          withVaList(args) {
+            result = vsscanf(dateString, format, $0)
+          }
         }
       }
     }

--- a/Sources/Clock/ISO8601Writer.swift
+++ b/Sources/Clock/ISO8601Writer.swift
@@ -1,7 +1,7 @@
 #if os(Linux)
-import Glibc
+    import Glibc
 #else
-import Darwin
+    import Darwin
 #endif
 
 import Foundation
@@ -19,11 +19,11 @@ private func epochToISO8601GMTString(epoch : Int) -> String? {
 }
 
 extension NSDate {
-  /// Get an ISO8601 compatible string representation
-  public func toISO8601GMTString() -> String? {
-    let epoch = Int(self.timeIntervalSince1970)
-    return epochToISO8601GMTString(epoch)
-  }
+    /// Get an ISO8601 compatible string representation
+    public func toISO8601GMTString() -> String? {
+        let epoch = Int(self.timeIntervalSince1970)
+        return epochToISO8601GMTString(epoch)
+    }
 }
 
 extension tm {

--- a/Sources/Clock/ISO8601Writer.swift
+++ b/Sources/Clock/ISO8601Writer.swift
@@ -8,15 +8,28 @@ import Foundation
 
 private let GMT_STRING_SIZE = Int(strlen("1971-02-03T09:16:06Z") + 1)
 
-extension NSDate {
-  /// Get an ISO8601 compatible string representation
-  public func toISO8601GMTString() -> String? {
-    var epoch = Int(self.timeIntervalSince1970)
+private func epochToISO8601GMTString(epoch : Int) -> String? {
+    var epoch = epoch
     var time: UnsafeMutablePointer<tm>
     time = gmtime(&epoch)
 
     let buffer = UnsafeMutablePointer<Int8>.alloc(GMT_STRING_SIZE)
     strftime(buffer, GMT_STRING_SIZE, "%FT%TZ", time);
     return String.fromCString(buffer)
+}
+
+extension NSDate {
+  /// Get an ISO8601 compatible string representation
+  public func toISO8601GMTString() -> String? {
+    let epoch = Int(self.timeIntervalSince1970)
+    return epochToISO8601GMTString(epoch)
   }
+}
+
+extension tm {
+    public func toISO8601GMTString() -> String? {
+        var tm_struct = self
+        let epoch = Int(timegm(&tm_struct))
+        return epochToISO8601GMTString(epoch)
+    }
 }

--- a/Tests/Localtime.swift
+++ b/Tests/Localtime.swift
@@ -3,29 +3,29 @@ import Clock
 import Foundation
 
 func describeLocaltimeDates() {
-  describe("Parsing of localtime dates") {
-    $0.it("can parse dates") {
-      let expected = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6, timeZoneOffset: 311 * 60)
+    describe("Parsing of localtime dates") {
+        $0.it("can parse dates") {
+            let expected = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6, timeZoneOffset: 311 * 60)
 
-      try expect(ISO8601.parse("1971-02-03T09:16:06.789+05:11")) == expected
-      try expect(ISO8601.parse("1971-02-03T09:16:06+05:11")) == expected
-      try expect(ISO8601.parse("1971-02-03T09:16:06.7+05:11")) == expected
-      try expect(ISO8601.parse("1971-02-03T09:16:06+05:11")) == expected
+            try expect(ISO8601.parse("1971-02-03T09:16:06.789+05:11")) == expected
+            try expect(ISO8601.parse("1971-02-03T09:16:06+05:11")) == expected
+            try expect(ISO8601.parse("1971-02-03T09:16:06.7+05:11")) == expected
+            try expect(ISO8601.parse("1971-02-03T09:16:06+05:11")) == expected
+        }
+
+        $0.it("can parse dates with negative timezone offsets") {
+            let expected = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6, timeZoneOffset: -311 * 60)
+
+            try expect(ISO8601.parse("1971-02-03T09:16:06.789-05:11")) == expected
+        }
+
+        $0.it("can parse timezone offsets without colons") {
+            let expected = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6, timeZoneOffset: 311 * 60)
+
+            try expect(ISO8601.parse("1971-02-03T09:16:06.789+0511")) == expected
+            try expect(ISO8601.parse("1971-02-03T09:16:06.78+0511")) == expected
+            try expect(ISO8601.parse("1971-02-03T09:16:06.7+0511")) == expected
+            try expect(ISO8601.parse("1971-02-03T09:16:06+0511")) == expected
+        }
     }
-
-    $0.it("can parse dates with negative timezone offsets") {
-      let expected = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6, timeZoneOffset: -311 * 60)
-
-      try expect(ISO8601.parse("1971-02-03T09:16:06.789-05:11")) == expected
-    }
-
-    $0.it("can parse timezone offsets without colons") {
-      let expected = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6, timeZoneOffset: 311 * 60)
-
-      try expect(ISO8601.parse("1971-02-03T09:16:06.789+0511")) == expected
-      try expect(ISO8601.parse("1971-02-03T09:16:06.78+0511")) == expected
-      try expect(ISO8601.parse("1971-02-03T09:16:06.7+0511")) == expected
-      try expect(ISO8601.parse("1971-02-03T09:16:06+0511")) == expected
-    }
-  }
 }

--- a/Tests/String.swift
+++ b/Tests/String.swift
@@ -3,27 +3,27 @@ import Clock
 import Foundation
 
 extension NSDateComponents {
-  func toDate() -> NSDate {
-    let calendar = NSCalendar(identifier: NSCalendarIdentifierGregorian)
-    return calendar?.dateFromComponents(self) ?? NSDate()
-  }
+    func toDate() -> NSDate {
+        let calendar = NSCalendar(identifier: NSCalendarIdentifierGregorian)
+        return calendar?.dateFromComponents(self) ?? NSDate()
+    }
 }
 
 func describeDateToStringConversion() {
-  describe("Converting dates to strings") {
-    $0.it("can convert TM struct to an ISO8601 GMT string") {
-        let actual = tm_struct(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6)
+    describe("Converting dates to strings") {
+        $0.it("can convert TM struct to an ISO8601 GMT string") {
+            let actual = tm_struct(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6)
 
-        try expect(actual.toISO8601GMTString()) == "1971-02-03T09:16:06Z"
+            try expect(actual.toISO8601GMTString()) == "1971-02-03T09:16:06Z"
+        }
+
+        #if !os(Linux)
+            $0.it("can convert NSDate to an ISO8601 GMT string") {
+                let input = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6)
+                let actual = input.toDate()
+
+                try expect(actual.toISO8601GMTString()) == "1971-02-03T09:16:06Z"
+            }
+        #endif
     }
-
-#if !os(Linux)
-    $0.it("can convert NSDate to an ISO8601 GMT string") {
-      let input = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6)
-      let actual = input.toDate()
-
-      try expect(actual.toISO8601GMTString()) == "1971-02-03T09:16:06Z"
-    }
-#endif
-  }
 }

--- a/Tests/String.swift
+++ b/Tests/String.swift
@@ -11,10 +11,17 @@ extension NSDateComponents {
 
 func describeDateToStringConversion() {
   describe("Converting dates to strings") {
+    $0.it("can convert TM struct to an ISO8601 GMT string") {
+        let actual = tm_struct(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6)
+
+        try expect(actual.toISO8601GMTString()) == "1971-02-03T09:16:06Z"
+    }
+
     $0.it("can convert NSDate to an ISO8601 GMT string") {
       let input = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6)
+      let actual = input.toDate()
 
-      try expect(input.toDate().toISO8601GMTString()) == "1971-02-03T09:16:06Z"
+      try expect(actual.toISO8601GMTString()) == "1971-02-03T09:16:06Z"
     }
   }
 }

--- a/Tests/String.swift
+++ b/Tests/String.swift
@@ -17,11 +17,13 @@ func describeDateToStringConversion() {
         try expect(actual.toISO8601GMTString()) == "1971-02-03T09:16:06Z"
     }
 
+#if !os(Linux)
     $0.it("can convert NSDate to an ISO8601 GMT string") {
       let input = components(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6)
       let actual = input.toDate()
 
       try expect(actual.toISO8601GMTString()) == "1971-02-03T09:16:06Z"
     }
+#endif
   }
 }

--- a/Tests/TMStruct.swift
+++ b/Tests/TMStruct.swift
@@ -9,7 +9,7 @@ import Glibc
 func tm_struct(year year: Int = 0, month: Int = 0, day: Int = 0,
     hour: Int = 0, minute: Int = 0, second: Int = 0,
     timeZoneOffset: NSTimeInterval = 0) -> tm {
-    return tm(tm_sec: Int32(second), tm_min: Int32(minute), tm_hour: Int32(hour), tm_mday: Int32(day), tm_mon: Int32(month), tm_year: Int32(year), tm_wday: 0, tm_yday: 0, tm_isdst: 0, tm_gmtoff: Int(timeZoneOffset), tm_zone: nil)
+    return tm(tm_sec: Int32(second), tm_min: Int32(minute), tm_hour: Int32(hour), tm_mday: Int32(day), tm_mon: Int32(month - 1), tm_year: Int32(year - 1900), tm_wday: 0, tm_yday: 0, tm_isdst: 0, tm_gmtoff: Int(timeZoneOffset), tm_zone: nil)
     }
 
 extension tm : Equatable {}

--- a/Tests/TMStruct.swift
+++ b/Tests/TMStruct.swift
@@ -3,28 +3,36 @@ import Clock
 import Foundation
 
 #if os(Linux)
-import Glibc
+    import Glibc
 #endif
 
 func tm_struct(year year: Int = 0, month: Int = 0, day: Int = 0,
-    hour: Int = 0, minute: Int = 0, second: Int = 0,
-    timeZoneOffset: NSTimeInterval = 0) -> tm {
+                    hour: Int = 0, minute: Int = 0, second: Int = 0,
+                    timeZoneOffset: NSTimeInterval = 0) -> tm {
     return tm(tm_sec: Int32(second), tm_min: Int32(minute), tm_hour: Int32(hour), tm_mday: Int32(day), tm_mon: Int32(month - 1), tm_year: Int32(year - 1900), tm_wday: 0, tm_yday: 0, tm_isdst: 0, tm_gmtoff: Int(timeZoneOffset), tm_zone: nil)
-    }
+}
 
 extension tm : Equatable {}
 
 public func ==(lhs: tm, rhs: tm) -> Bool {
-	return lhs.tm_sec == rhs.tm_sec && lhs.tm_min == rhs.tm_min && lhs.tm_hour == rhs.tm_hour && lhs.tm_mday == rhs.tm_mday && lhs.tm_mon == rhs.tm_mon && lhs.tm_year == rhs.tm_year && lhs.tm_wday == rhs.tm_wday && lhs.tm_yday == rhs.tm_yday && lhs.tm_isdst == rhs.tm_isdst && lhs.tm_gmtoff == rhs.tm_gmtoff && lhs.tm_zone == rhs.tm_zone
+    return lhs.tm_sec == rhs.tm_sec && lhs.tm_min == rhs.tm_min && lhs.tm_hour == rhs.tm_hour && lhs.tm_mday == rhs.tm_mday && lhs.tm_mon == rhs.tm_mon && lhs.tm_year == rhs.tm_year && lhs.tm_wday == rhs.tm_wday && lhs.tm_yday == rhs.tm_yday && lhs.tm_isdst == rhs.tm_isdst && lhs.tm_gmtoff == rhs.tm_gmtoff && lhs.tm_zone == rhs.tm_zone
 }
 
 func describeTMStruct() {
-	describe("Conversion to TM struct") {
-	$0.it("can parse dates") {
-      let expected = tm_struct(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6, timeZoneOffset: 311 * 60)
+    describe("Conversion to TM struct") {
+        $0.it("can parse dates") {
+            let expected = tm_struct(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6, timeZoneOffset: 311 * 60)
 
-      let tm_value: tm = ISO8601.parse("1971-02-03T09:16:06.789+05:11")
-      try expect(tm_value) == expected
-      }
-	}
+            try expect(ISO8601.parse("1971-02-03T09:16:06.789+05:11")) == expected
+        }
+
+        $0.it("can parse dates without seconds") {
+            try expect(ISO8601.parse("1971-02-03T04:05Z")) == tm_struct(year: 1971, month: 2, day: 3, hour: 4, minute: 5)
+        }
+
+        $0.it("is resilient against Y2K bugs") {
+            try expect(ISO8601.parse("2058-02-20T18:29:11.100Z")) == tm_struct(year: 2058, month: 2, day: 20, hour: 18, minute: 29, second: 11)
+            try expect(ISO8601.parse("3001-01-01T08:00:00.000Z")) == tm_struct(year: 3001, month: 1, day: 1, hour: 8)
+        }
+    }
 }

--- a/Tests/TMStruct.swift
+++ b/Tests/TMStruct.swift
@@ -2,6 +2,10 @@ import Spectre
 import Clock
 import Foundation
 
+#if os(Linux)
+import Glibc
+#endif
+
 func tm_struct(year year: Int = 0, month: Int = 0, day: Int = 0,
     hour: Int = 0, minute: Int = 0, second: Int = 0,
     timeZoneOffset: NSTimeInterval = 0) -> tm {

--- a/Tests/TMStruct.swift
+++ b/Tests/TMStruct.swift
@@ -1,0 +1,26 @@
+import Spectre
+import Clock
+import Foundation
+
+func tm_struct(year year: Int = 0, month: Int = 0, day: Int = 0,
+    hour: Int = 0, minute: Int = 0, second: Int = 0,
+    timeZoneOffset: NSTimeInterval = 0) -> tm {
+    return tm(tm_sec: Int32(second), tm_min: Int32(minute), tm_hour: Int32(hour), tm_mday: Int32(day), tm_mon: Int32(month), tm_year: Int32(year), tm_wday: 0, tm_yday: 0, tm_isdst: 0, tm_gmtoff: Int(timeZoneOffset), tm_zone: nil)
+    }
+
+extension tm : Equatable {}
+
+public func ==(lhs: tm, rhs: tm) -> Bool {
+	return lhs.tm_sec == rhs.tm_sec && lhs.tm_min == rhs.tm_min && lhs.tm_hour == rhs.tm_hour && lhs.tm_mday == rhs.tm_mday && lhs.tm_mon == rhs.tm_mon && lhs.tm_year == rhs.tm_year && lhs.tm_wday == rhs.tm_wday && lhs.tm_yday == rhs.tm_yday && lhs.tm_isdst == rhs.tm_isdst && lhs.tm_gmtoff == rhs.tm_gmtoff && lhs.tm_zone == rhs.tm_zone
+}
+
+func describeTMStruct() {
+	describe("Conversion to TM struct") {
+	$0.it("can parse dates") {
+      let expected = tm_struct(year: 1971, month: 2, day: 3, hour: 9, minute: 16, second: 6, timeZoneOffset: 311 * 60)
+
+      let tm_value: tm = ISO8601.parse("1971-02-03T09:16:06.789+05:11")
+      try expect(tm_value) == expected
+      }
+	}
+}

--- a/Tests/UTC.swift
+++ b/Tests/UTC.swift
@@ -3,41 +3,41 @@ import Clock
 import Foundation
 
 func components(year year: Int = 0, month: Int = 0, day: Int = 0,
-    hour: Int = 0, minute: Int = 0, second: Int = 0,
-    timeZoneOffset: NSTimeInterval = 0) -> NSDateComponents {
-  let components = NSDateComponents()
-  components.year = year
-  components.month = month
-  components.day = day
-  components.hour = hour
-  components.minute = minute
-  components.second = second
-  components.timeZone = NSTimeZone(forSecondsFromGMT: Int(timeZoneOffset))
-  return components
+                     hour: Int = 0, minute: Int = 0, second: Int = 0,
+                     timeZoneOffset: NSTimeInterval = 0) -> NSDateComponents {
+    let components = NSDateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    components.hour = hour
+    components.minute = minute
+    components.second = second
+    components.timeZone = NSTimeZone(forSecondsFromGMT: Int(timeZoneOffset))
+    return components
 }
 
 func describeUTCDates() {
-  describe("Parsing of UTC dates") {
-    $0.it("can parse dates") {
-      let expected = components(year: 1971, month: 2, day: 3, hour: 4, minute: 5, second: 6)
+    describe("Parsing of UTC dates") {
+        $0.it("can parse dates") {
+            let expected = components(year: 1971, month: 2, day: 3, hour: 4, minute: 5, second: 6)
 
-      try expect(ISO8601.parse("1971-02-03T04:05:06.789Z")) == expected
-      try expect(ISO8601.parse("1971-02-03T04:05:06.78Z")) == expected
-      try expect(ISO8601.parse("1971-02-03T04:05:06.7Z")) == expected
-      try expect(ISO8601.parse("1971-02-03T04:05:06Z")) == expected
-    }
+            try expect(ISO8601.parse("1971-02-03T04:05:06.789Z")) == expected
+            try expect(ISO8601.parse("1971-02-03T04:05:06.78Z")) == expected
+            try expect(ISO8601.parse("1971-02-03T04:05:06.7Z")) == expected
+            try expect(ISO8601.parse("1971-02-03T04:05:06Z")) == expected
+        }
 
-    $0.it("can parse epoch") {
-      try expect(ISO8601.parse("1970-01-01T00:00:00.000Z")) == components(year: 1970, month: 1, day: 1)
-    }
+        $0.it("can parse epoch") {
+            try expect(ISO8601.parse("1970-01-01T00:00:00.000Z")) == components(year: 1970, month: 1, day: 1)
+        }
 
-    $0.it("can parse dates without seconds") {
-      try expect(ISO8601.parse("1971-02-03T04:05Z")) == components(year: 1971, month: 2, day: 3, hour: 4, minute: 5)
-    }
+        $0.it("can parse dates without seconds") {
+            try expect(ISO8601.parse("1971-02-03T04:05Z")) == components(year: 1971, month: 2, day: 3, hour: 4, minute: 5)
+        }
 
-    $0.it("is resilient against Y2K bugs") {
-      try expect(ISO8601.parse("2058-02-20T18:29:11.100Z")) == components(year: 2058, month: 2, day: 20, hour: 18, minute: 29, second: 11)
-      try expect(ISO8601.parse("3001-01-01T08:00:00.000Z")) == components(year: 3001, month: 1, day: 1, hour: 8)
+        $0.it("is resilient against Y2K bugs") {
+            try expect(ISO8601.parse("2058-02-20T18:29:11.100Z")) == components(year: 2058, month: 2, day: 20, hour: 18, minute: 29, second: 11)
+            try expect(ISO8601.parse("3001-01-01T08:00:00.000Z")) == components(year: 3001, month: 1, day: 1, hour: 8)
+        }
     }
-  }
 }

--- a/Tests/main.swift
+++ b/Tests/main.swift
@@ -1,4 +1,6 @@
-describeDateToStringConversion()
+#if !os(Linux)
 describeLocaltimeDates()
 describeUTCDates()
+#endif
 describeTMStruct()
+describeDateToStringConversion()

--- a/Tests/main.swift
+++ b/Tests/main.swift
@@ -1,3 +1,4 @@
 describeDateToStringConversion()
 describeLocaltimeDates()
 describeUTCDates()
+describeTMStruct()


### PR DESCRIPTION
The branch name is quite misleading since this now does a bunch of things:
- Use `withVaList` instead of `getVaList`
- Implement conversions to and from `tm`structures so that Linux support actually makes sense
- Reindent code with Xcode defaults
